### PR TITLE
refactor(CH12): hardware-agnostic accelerator detection

### DIFF
--- a/CH12_FLYNN_ML4DD/src/utils.py
+++ b/CH12_FLYNN_ML4DD/src/utils.py
@@ -59,4 +59,4 @@ def get_device() -> torch.device:
                      PyTorch computations (either CUDA or CPU).
     """
 
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(torch.accelerator.current_accelerator() if torch.accelerator.is_available() else "cpu")


### PR DESCRIPTION
 ## Summary
 - `get_device()` in `CH12_FLYNN_ML4DD/src/utils.py` only checked `torch.cuda.is_available()`, so any non-CUDA accelerator (MPS on Apple Silicon, XPU on Intel, etc.) silently fell back to CPU.
 - Switch to `torch.accelerator.current_accelerator()` / `torch.accelerator.is_available()` (PyTorch's generic accelerator API) so the correct backend is picked automatically, with CPU as the final fallback.
 - No callers change: `train_plm.py` already consumes `get_device()` as an opaque `torch.device` (see `device = get_device()` at `train_plm.py:307`).

## Implementation
- A one line change in CH12_FLYNN_ML4DD/src/utils.py on `get_device()`